### PR TITLE
Add init.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openfisca-uk-data",
-    version="0.1.3",
+    version="0.1.4",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),


### PR DESCRIPTION
For some reason, the ukmod folder is not accessible when pip installing the repo, but is locally. I think it's because of a missing __init__.py.