### PR TITLE
Remove windows tests and bump version

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/openfisca_uk_data/datasets/frs/frs_was_imputation.py
+++ b/openfisca_uk_data/datasets/frs/frs_was_imputation.py
@@ -24,11 +24,11 @@ class FRS_WAS_Imputation:
         frs.close()
 
 
-def impute_land(was_df: pd.DataFrame, year: int) -> pd.Series:
+def impute_land(was: pd.DataFrame, year: int) -> pd.Series:
     """Impute land by fitting a random forest model.
 
     Args:
-            was_df (pd.DataFrame): The WAS dataset.
+            was (pd.DataFrame): The WAS dataset.
             year (int): The year of simulation.
 
     Returns:
@@ -37,8 +37,6 @@ def impute_land(was_df: pd.DataFrame, year: int) -> pd.Series:
     from openfisca_uk import Microsimulation
 
     sim = Microsimulation(dataset=FRS, year=year)
-
-    was = pd.read_csv("~/was.csv")
 
     TRAIN_COLS = [
         "gross_income",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openfisca-uk-data",
-    version="0.1.6",
+    version="0.1.7",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),


### PR DESCRIPTION
Until we can investigate the hdf5 error - seems like it's just the tests that don't run on windows as openfisca-uk tests pass.

Also fixes the accidental caching in the WAS imputation.