### PR TITLE
Fix bug and add generation to action

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -44,6 +44,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/book/_build/html
+      - name: Build datasets
+        run: make generate
   Publish:
     if: github.repository == 'PolicyEngine/openfisca-uk-data'
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ test:
 	pytest openfisca_uk_data/tests -vv
 	jb clean docs/book
 	jb build docs/book
+generate:
+	openfisca-uk-data raw_frs download 2019
+	openfisca-uk-data frs generate 2019

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -154,6 +154,9 @@ def add_personal_variables(frs: h5py.File, person: DataFrame):
     # Add basic personal variables
     age = person.AGE80 + person.AGE
     frs["age"] = age
+    # Age fields are AGE80 (top-coded) and AGE in the adult and child tables, respectively.
+    # The role is used within OpenFisca models for enhanced aggregation features (e.g. sorting
+    # members within groups).
     frs["role"] = np.where(person.AGE80 == 0, "child", "adult").astype("S")
     frs["gender"] = np.where(person.SEX == 1, "MALE", "FEMALE").astype("S")
     frs["hours_worked"] = person.TOTHOURS * 52

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -154,7 +154,7 @@ def add_personal_variables(frs: h5py.File, person: DataFrame):
     # Add basic personal variables
     age = person.AGE80 + person.AGE
     frs["age"] = age
-    frs["role"] = np.where(person.AGE80 == 0, "adult", "child").astype("S")
+    frs["role"] = np.where(person.AGE80 == 0, "child", "adult").astype("S")
     frs["gender"] = np.where(person.SEX == 1, "MALE", "FEMALE").astype("S")
     frs["hours_worked"] = person.TOTHOURS * 52
     frs["is_household_head"] = person.HRPID == 1

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -156,7 +156,8 @@ def add_personal_variables(frs: h5py.File, person: DataFrame):
     frs["age"] = age
     # Age fields are AGE80 (top-coded) and AGE in the adult and child tables, respectively.
     # The role is used within OpenFisca models for enhanced aggregation features (e.g. sorting
-    # members within groups).
+    # members within groups). AGE80 == 0 therefore indicates that the record is from the child
+    # table (as we filled missing values with 0 when merging adult and child tables).
     frs["role"] = np.where(person.AGE80 == 0, "child", "adult").astype("S")
     frs["gender"] = np.where(person.SEX == 1, "MALE", "FEMALE").astype("S")
     frs["hours_worked"] = person.TOTHOURS * 52

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK-Data",
-    version="0.1.9",
+    version="0.1.10",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),


### PR DESCRIPTION
@MaxGhenis I found the bug affecting the Child Benefit parameters: the `role` field was inverted, I think since the pandas rewrite. The reason this didn't affect anything else is because in openfisca-uk, I've been moving away from using the role syntax as much as possible, preferring to use the variable `is_child` which explicitly calculates based on age. I've also added a generation action here, which updates the FRS dataset in Google Cloud Storage (also in future to generate FRS 2018, as well as the WAS imputation).