### PR TITLE
Add Enhanced FRS

### DIFF
--- a/docs/book/imputation.md
+++ b/docs/book/imputation.md
@@ -77,3 +77,23 @@ We're working on improvements to the land imputation:
 * [Uprating WAS data](https://github.com/PolicyEngine/openfisca-uk-data/issues/34) to account for wealth growth from 2018 to 2020
 * [Adding region to the WAS-FRS imputation](https://github.com/PolicyEngine/openfisca-uk-data/issues/21)
 * [Reporting model quality](https://github.com/PolicyEngine/openfisca-uk-data/issues/22) by summarizing quantile loss on a holdout set
+
+## Imputing carbon emissions to the FRS
+
+The Family Resources Survey does not contain consumption information on its respondents. However, the Living Costs and Food Survey does, and we can use it to estimate carbon emissions.
+
+To do this, we also use the [official estimates of the UK's carbon footprint](https://www.gov.uk/government/statistics/uks-carbon-footprint). These estimate the carbon emissions produced by each category of consumption. `ncfs_emissions_2019.csv` contains these estimates for 2019, along with their category names and [COICOP codes](https://unstats.un.org/unsd/classifications/unsdclassifications/COICOP_2018_-_pre-edited_white_cover_version_-_2018-12-26.pdf). We use these estimates to estimate the carbon emissions produced by each household first in the LCFS, then in the FRS.
+
+To estimate emissions produced by households in the LCFS, we use the shared categories of consumption: finding the total expenditure by households for each major category from the LCFS, and the total emissions produced by each category from the carbon footprint estimates. Then, we divide the emissions by the expenditure to find the carbon intensity of each category - the tonnes of C02 associated with each pound spent, per category. With this, we mutliply each households's expenditure in each category by that category's carbon intensity to find the total emissions produced by that household.
+
+LCFS households share some variables with FRS households:
+
+* Number of adults
+* Number of children
+* UK region
+* Employment income
+* Self-employment income
+* State pension
+* Pension income
+
+Similarly to land value, we fit a random forest model to predict carbon emissions from those predictors in the LCFS, then sample from the predicted distribution for FRS households to estimate the emissions produced by each household in the FRS.

--- a/openfisca_uk_data/__init__.py
+++ b/openfisca_uk_data/__init__.py
@@ -9,4 +9,5 @@ DATASETS = (
     FRS_SPI_Adjusted,
     FRS_WAS_Imputation,
     SPI,
+    RawLCF,
 )

--- a/openfisca_uk_data/cli.py
+++ b/openfisca_uk_data/cli.py
@@ -16,6 +16,8 @@ def main():
             FRS_SPI_Adjusted,
             FRS_WAS_Imputation,
             RawWAS,
+            RawLCF,
+            FRSEnhanced,
         )
     }
     parser = ArgumentParser(

--- a/openfisca_uk_data/datasets/__init__.py
+++ b/openfisca_uk_data/datasets/__init__.py
@@ -1,3 +1,4 @@
 from openfisca_uk_data.datasets.frs import *
 from openfisca_uk_data.datasets.spi import *
 from openfisca_uk_data.datasets.was import *
+from openfisca_uk_data.datasets.lcf import *

--- a/openfisca_uk_data/datasets/frs/__init__.py
+++ b/openfisca_uk_data/datasets/frs/__init__.py
@@ -8,3 +8,4 @@ from openfisca_uk_data.datasets.frs.frs_was_imputation import (
     FRS_WAS_Imputation,
 )
 from openfisca_uk_data.datasets.frs.synth_frs import SynthFRS
+from openfisca_uk_data.datasets.frs.frs_enhanced import FRSEnhanced

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -315,7 +315,9 @@ def add_household_variables(frs: h5py.File, household: DataFrame):
     CT_imputed = hh_CT_mean
     council_tax = pd.Series(
         np.where(
-            (household.CTANNUAL < 0),
+            # 2018 FRS uses blanks for missing values, 2019 FRS
+            # uses -1 for missing values
+            (household.CTANNUAL < 0) | household.CTANNUAL.isna(),
             max_(CT_imputed, 0).values,
             household.CTANNUAL,
         )

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/README.md
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/README.md
@@ -1,0 +1,14 @@
+# Enhanced FRS
+
+This folder contains the definition of the enhanced FRS dataset, which imputes data from:
+* The Living Costs and Food Survey (consumption)
+* The Wealth and Assets Survey (assets)
+onto the Family Resources Survey (income).
+
+## LCF Imputations
+
+The LCF dataset contains consumption data, but not carbon emissions. To estimate carbon emissions, we use [official estimates of the UK's carbon footprint](https://www.gov.uk/government/statistics/uks-carbon-footprint). These estimate the carbon emissions produced by each category of consumption. `ncfs_emissions_2019.csv` contains these estimates for 2019, along with their category names and [COICOP codes](https://unstats.un.org/unsd/classifications/unsdclassifications/COICOP_2018_-_pre-edited_white_cover_version_-_2018-12-26.pdf).
+
+## WAS Imputations
+
+The WAS dataset contains measures of property and corporate wealth, which we use to estimate the total land value tax exposure.

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/__init__.py
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/__init__.py
@@ -1,0 +1,3 @@
+from openfisca_uk_data.datasets.frs.frs_enhanced.frs_enhanced import (
+    FRSEnhanced,
+)

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/frs_enhanced.py
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/frs_enhanced.py
@@ -1,0 +1,46 @@
+from openfisca_uk_data.datasets.was.raw_was import RawWAS
+from openfisca_uk_data.utils import dataset, UK
+from openfisca_uk_data.datasets.frs.frs import FRS
+from openfisca_uk_data.datasets.frs.frs_enhanced.was_imputation import (
+    impute_land,
+)
+from openfisca_uk_data.datasets.frs.frs_enhanced.lcf_imputation import (
+    impute_carbon,
+)
+import h5py
+import numpy as np
+from time import time
+
+
+@dataset
+class FRSEnhanced:
+    name = "frs_enhanced"
+    model = UK
+
+    def generate(year: int) -> None:
+        print("Imputing FRS land value exposure...", end="", flush=True)
+        t = time()
+        pred_land = impute_land(year)
+        print(
+            f" (completed in {round(time() - t, 1)}s)\nImputing FRS carbon consumption...",
+            end="",
+            flush=True,
+        )
+        t = time()
+        pred_carbon = impute_carbon(year)
+        print(
+            f" (completed in {round(time() - t, 1)}s)\nGenerating default FRS...",
+            end="",
+            flush=True,
+        )
+        t = time()
+        frs_enhanced = h5py.File(FRSEnhanced.file(year), mode="w")
+        FRS.generate(year)
+        frs = FRS.load(year)
+        for variable in tuple(frs.keys()):
+            frs_enhanced[variable] = np.array(frs[variable][...])
+        frs_enhanced["land_value"] = pred_land
+        frs_enhanced["carbon_consumption"] = pred_carbon
+        frs_enhanced.close()
+        frs.close()
+        print(f" (completed in {round(time() - t, 1)}s)\nDone", flush=True)

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/lcf_imputation.py
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/lcf_imputation.py
@@ -1,0 +1,228 @@
+from typing import Tuple
+import pandas as pd
+from pathlib import Path
+from openfisca_uk_data.datasets.frs.frs import FRS
+from openfisca_uk_data.datasets.lcf import RawLCF
+from microdf import MicroDataFrame
+import synthimpute as si
+
+CATEGORY_NAMES = {
+    1: "Food and non-alcoholic beverages",
+    2: "Alcohol and tobacco",
+    3: "Clothing and footwear",
+    4: "Housing, water and electricity",
+    5: "Household furnishings",
+    6: "Health",
+    7: "Transport",
+    8: "Communication",
+    9: "Recreation",
+    10: "Education",
+    11: "Restaurants and hotels",
+    12: "Miscellaneous",
+}
+
+HOUSEHOLD_LCF_RENAMES = {
+    "G018": "is_adult",
+    "G019": "is_child",
+    "Gorx": "region",
+}
+PERSON_LCF_RENAMES = {
+    "B303p": "employment_income",
+    "B3262p": "self_employment_income",
+    "B3381": "state_pension",
+    "P049p": "pension_income",
+}
+REGIONS = {
+    1: "NORTH_EAST",
+    2: "NORTH_WEST",
+    3: "YORKSHIRE",
+    4: "EAST_MIDLANDS",
+    5: "WEST_MIDLANDS",
+    6: "EAST_OF_ENGLAND",
+    7: "LONDON",
+    8: "SOUTH_EAST",
+    9: "SOUTH_WEST",
+    10: "WALES",
+    11: "SCOTLAND",
+    12: "NORTHERN_IRELAND",
+}
+
+
+def impute_carbon(year: int) -> pd.Series:
+    """Impute carbon consumption by fitting a random forest model.
+
+    Args:
+        year (int): The year of LCFS to use.
+
+    Returns:
+        pd.Series: The imputed carbon consumption.
+    """
+
+    # Load the LCF data with carbon consumption
+    lcf = load_lcfs_with_carbon(year)
+    # Impute LCF carbon consumption to FRS households
+    carbon = impute_carbon_to_FRS(lcf, year)
+    return carbon
+
+
+def impute_carbon_to_FRS(lcf: MicroDataFrame, year: int) -> pd.Series:
+    """Impute carbon consumption to the FRS.
+
+    Args:
+        lcf (MicroDataFrame): The LCF data.
+        year (int): The year of the FRS to use.
+
+    Returns:
+        pd.Series: The imputed carbon consumption.
+    """
+
+    from openfisca_uk import Microsimulation
+
+    sim = Microsimulation(dataset=FRS, year=year)
+
+    frs = sim.df(
+        [
+            "is_adult",
+            "is_child",
+            "region",
+            "employment_income",
+            "self_employment_income",
+            "state_pension",
+            "pension_income",
+        ],
+        map_to="household",
+    )
+
+    frs.region = frs.region.map(
+        {name: float(i) for i, name in REGIONS.items()}
+    )
+    lcf.region = lcf.region.map(
+        {name: float(i) for i, name in REGIONS.items()}
+    )
+
+    return si.rf_impute(
+        x_train=lcf.drop(["carbon_tonnes"], axis=1),
+        y_train=lcf.carbon_tonnes,
+        x_new=frs,
+    )
+
+
+def load_lcfs_with_carbon(year: int) -> MicroDataFrame:
+    """Load LCF data with carbon consumption.
+
+    Args:
+        year (int): The year of LCFS to use.
+
+    Returns:
+        MicroDataFrame: The LCF data with carbon consumption.
+    """
+    households, people, emissions = load_and_process_lcf(year)
+
+    # Manipulate LCF and NCFS data to get expenditure on the same categories
+    # Both datasets use the COICOP classification
+    # Documentation: https://unstats.un.org/unsd/classifications/unsdclassifications/COICOP_2018_-_pre-edited_white_cover_version_-_2018-12-26.pdf
+
+    index_to_col = {i: f"P6{i:02}" for i in CATEGORY_NAMES}
+    spending = (
+        households[list(index_to_col.values())]
+        .rename(columns={y: x for x, y in index_to_col.items()})
+        .unstack()
+        .reset_index()
+    )
+    spending.columns = "category", "household", "spending"
+    spending["household"] = households.case[spending.household].values
+    households = households.set_index("case")
+    spending.category = spending.category.map(CATEGORY_NAMES)
+    spending.spending *= 52
+    spending["weight"] = households.weighta[spending.household].values * 1000
+    spending = MicroDataFrame(spending, weights=spending.weight)
+    emissions.index = emissions.index.astype(str)
+    spending_by_category = spending.groupby("category").spending.sum()
+
+    grouped_ncfs = pd.DataFrame(
+        {
+            code: {
+                "category": CATEGORY_NAMES[code],
+                "carbon_tonnes": emissions[
+                    emissions.index.str.startswith(str(code))
+                ].carbon_tonnes.sum(),
+            }
+            for code in CATEGORY_NAMES.keys()
+        }
+    ).T.set_index("category")
+
+    # For each category, calculate spending from the LCFS and carbon emissions
+    # from the NCFS. Then, divide to find the carbon emissions per pound spent
+
+    carbon_by_category = pd.DataFrame(
+        {
+            category: {
+                "carbon_tonnes": grouped_ncfs.carbon_tonnes[category],
+                "spending": spending_by_category[category],
+            }
+            for category in spending.category.unique()
+        }
+    ).T
+
+    carbon_by_category["carbon_per_pound"] = (
+        carbon_by_category.carbon_tonnes / carbon_by_category.spending
+    )
+
+    # Multiple spending by carbon intensity to calculate LCF households' carbon footprints
+    spending["carbon_tonnes"] = (
+        carbon_by_category.carbon_per_pound[spending.category].values
+        * spending.spending
+    )
+    lcf_with_carbon = (
+        pd.DataFrame(spending[["household", "carbon_tonnes", "weight"]])
+        .groupby("household")
+        .sum()
+    )
+
+    # Add in LCF variables that also appear in the FRS-based microsimulation model
+
+    lcf_with_carbon = pd.concat(
+        [
+            lcf_with_carbon,
+            households[list(HOUSEHOLD_LCF_RENAMES.keys())].rename(
+                columns=HOUSEHOLD_LCF_RENAMES
+            ),
+            people[list(PERSON_LCF_RENAMES) + ["case"]]
+            .rename(columns=PERSON_LCF_RENAMES)
+            .groupby("case")
+            .sum(),
+        ],
+        axis=1,
+    )
+
+    # LCF incomes are weekly - convert to annual
+    for variable in PERSON_LCF_RENAMES.values():
+        lcf_with_carbon[variable] *= 52
+
+    lcf_with_carbon.region = lcf_with_carbon.region.map(REGIONS)
+    lcf = lcf_with_carbon.sort_index()
+
+    # Return household-level LCF dataset with carbon consumption
+    # and FRS-shared columns
+    return MicroDataFrame(lcf, weights=households.weighta[lcf.index] * 1000)
+
+
+def load_and_process_lcf(
+    year: int,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """
+    Load and process the LCF and NCFS summary data.
+
+    Args:
+        year (int): The year of LCFS to use.
+
+    Returns:
+        Tuple[DataFrame, DataFrame, DataFrame]: The LCF household, person and NCFS emissions data.
+    """
+    households = RawLCF.load(2019, "lcfs_2019_dvhh_ukanon")
+    people = RawLCF.load(2019, "lcfs_2019_dvper_ukanon201920")
+    emissions = pd.read_csv(
+        Path(__file__).parent / "ncfs_emissions_2019.csv"
+    ).set_index("code_start")
+
+    return households, people, emissions

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/lcf_imputation.py
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/lcf_imputation.py
@@ -63,7 +63,6 @@ def impute_carbon(year: int) -> pd.Series:
 
     # Impute LCF carbon consumption to FRS households
     return impute_carbon_to_FRS(lcf, year)
-    return carbon
 
 
 def impute_carbon_to_FRS(lcf: MicroDataFrame, year: int) -> pd.Series:

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/ncfs_emissions_2019.csv
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/ncfs_emissions_2019.csv
@@ -1,0 +1,33 @@
+,category,code_start,carbon_tonnes
+0,Food,1.1,20541000
+1,Non-alcoholic beverages,1.2,1196000
+2,Alcoholic beverages,2.1,693000
+3,Tobacco,2.2,185000
+4,Clothing,3.1,6523000
+5,Footwear,3.2,1537000
+6,Actual rentals for households,4.1,6471000
+7,Maintenance and repair of the dwelling,4.2,1124000
+8,Water supply and miscellaneous dwelling services,4.3,1511000
+9,"Electricity, gas and other fuels",4.4,133206000
+10,"Furniture, furnishings, carpets etc",5.1,5564000
+11,Household textiles,5.2,2266000
+12,Household appliances,5.3,758000
+13,"Glassware, tableware and household utensils",5.4,2892000
+14,Tools and equipment for house and garden,5.5,407000
+15,Goods and services for household maintenance,5.6,491000
+16,"Medical products, appliances and equipment",6.1,6113000
+17,Hospital services,6.2,1159000
+18,Purchase of vehicles,7.1,7549000
+19,Operation of personal transport equipment,7.2,90195000
+20,Transport services,7.3,65877000
+21,Postal services,8.1,334000
+22,Telephone and telefax equipment,8.2,307000
+23,Telephone and telefax services,8.3,1992000
+24,"Audio-visual, photographic and information processing equipment",9.1,4497000
+25,Other major durables for recreation and culture,9.2,2874000
+26,Other recreational equipment etc,9.3,8369000
+27,Recreational and cultural services,9.4,4782000
+28,"Newspapers, books and stationery",9.5,1096000
+29,Education,10,1906000
+30,Restaurants and hotels,11,20670000
+31,Miscellaneous goods and services,12,15944000

--- a/openfisca_uk_data/datasets/frs/frs_enhanced/was_imputation.py
+++ b/openfisca_uk_data/datasets/frs/frs_enhanced/was_imputation.py
@@ -1,0 +1,150 @@
+from openfisca_uk_data.datasets.was.raw_was import RawWAS
+from openfisca_uk_data.datasets.frs.frs import FRS
+import pandas as pd
+import microdf as mdf
+import synthimpute as si
+
+
+def impute_land(year: int) -> pd.Series:
+    """Impute land by fitting a random forest model.
+
+    Args:
+            year (int): The year of simulation.
+
+    Returns:
+            pd.Series: The predicted land values.
+    """
+
+    was = load_and_process_was()
+
+    from openfisca_uk import Microsimulation
+
+    sim = Microsimulation(dataset=FRS, year=year)
+
+    TRAIN_COLS = [
+        "gross_income",
+        "num_adults",
+        "num_children",
+        "pension_income",
+        "employment_income",
+        "self_employment_income",
+        "investment_income",
+        "num_bedrooms",
+        "council_tax",
+        "is_renting",
+    ]
+
+    IMPUTE_COLS = [
+        "est_land",  # Estimated land value based on property and corporate wealth.
+    ]
+
+    # FRS has investment income split between dividend and savings interest.
+    frs_cols = [i for i in TRAIN_COLS if i != "investment_income"]
+    frs_cols += [
+        "dividend_income",
+        "savings_interest_income",
+        "people",
+        "net_income",
+        "household_weight",
+    ]
+
+    frs = sim.df(frs_cols, map_to="household", period=year)
+    frs["investment_income"] = (
+        frs.savings_interest_income + frs.dividend_income
+    )
+
+    return si.rf_impute(
+        x_train=was[TRAIN_COLS],
+        y_train=was[IMPUTE_COLS],
+        x_new=frs[TRAIN_COLS],
+        sample_weight_train=was.weight,
+        new_weight=frs.household_weight,
+        target=mdf.weighted_sum(was, "est_land", "weight"),
+    )
+
+
+def load_and_process_was() -> pd.DataFrame:
+    """Process the Wealth and Assets Survey household wealth file.
+
+    Returns:
+            pd.DataFrame: The processed dataframe.
+    """
+    RENAMES = {
+        "R6xshhwgt": "weight",
+        # Components for estimating land holdings.
+        "DVLUKValR6_sum": "uk_land",
+        "DVPropertyR6": "property_values",
+        "DVFESHARESR6_aggr": "emp_shares_options",
+        "DVFShUKVR6_aggr": "uk_shares",
+        "DVIISAVR6_aggr": "investment_isas",
+        "DVFCollVR6_aggr": "unit_investment_trusts",
+        "TotpenR6_aggr": "pensions",
+        "DvvalDBTR6_aggr": "db_pensions",
+        # Predictors for fusing to FRS.
+        "dvtotgirR6": "gross_income",
+        "NumAdultW6": "num_adults",
+        "NumCh18W6": "num_children",
+        # Household Gross Annual income from occupational or private pensions
+        "DVGIPPENR6_AGGR": "pension_income",
+        "DVGISER6_AGGR": "self_employment_income",
+        # Household Gross annual income from investments
+        "DVGIINVR6_aggr": "investment_income",
+        # Household Total Annual Gross employee income
+        "DVGIEMPR6_AGGR": "employment_income",
+        "HBedrmW6": "num_bedrooms",
+        "GORR6": "region",
+        "DVPriRntW6": "is_renter",  # {1, 2} TODO: Get codebook values.
+        "CTAmtW6": "council_tax",
+        # Other columns for reference.
+        "DVLOSValR6_sum": "non_uk_land",
+        "HFINWNTR6_Sum": "net_financial_wealth",
+        "DVLUKDebtR6_sum": "uk_land_debt",
+        "HFINWR6_Sum": "gross_financial_wealth",
+        "TotWlthR6": "wealth",
+    }
+
+    # TODO: Handle different WAS releases
+
+    was = (
+        RawWAS.load(2016, "was_round_6_hhold_eul_mar_20")
+        .rename(columns=RENAMES)
+        .fillna(0)
+    )
+
+    was["is_renting"] = was["is_renter"] == 1
+
+    # Land value held by households and non-profit institutions serving
+    # households: 3.9tn as of 2019 (ONS).
+    HH_NP_LAND_VALUE = 3_912_632e6
+    # Land value held by financial and non-financial corporations.
+    CORP_LAND_VALUE = 1_600_038e6
+    # Land value held by government (not used).
+    GOV_LAND_VALUE = 196_730e6
+
+    was["non_db_pensions"] = was.pensions - was.db_pensions
+    was["corp_wealth"] = was[
+        [
+            "non_db_pensions",
+            "emp_shares_options",
+            "uk_shares",
+            "investment_isas",
+            "unit_investment_trusts",
+        ]
+    ].sum(axis=1)
+
+    totals = mdf.weighted_sum(
+        was, ["uk_land", "property_values", "corp_wealth"], "weight"
+    )
+
+    land_prop_share = (
+        HH_NP_LAND_VALUE - totals.uk_land
+    ) / totals.property_values
+    land_corp_share = CORP_LAND_VALUE / totals.corp_wealth
+
+    was["est_land"] = (
+        was.uk_land
+        + was.property_values * land_prop_share
+        + was.corp_wealth * land_corp_share
+    )
+
+    return was

--- a/openfisca_uk_data/datasets/lcf/__init__.py
+++ b/openfisca_uk_data/datasets/lcf/__init__.py
@@ -1,0 +1,1 @@
+from openfisca_uk_data.datasets.lcf.raw_lcf import RawLCF

--- a/openfisca_uk_data/datasets/lcf/raw_lcf.py
+++ b/openfisca_uk_data/datasets/lcf/raw_lcf.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from openfisca_uk_data.utils import dataset
+import pandas as pd
+import shutil
+from openfisca_uk_data.utils import safe_rmdir
+import re
+from tqdm import tqdm
+
+
+@dataset
+class RawLCF:
+    name = "raw_lcf"
+
+    def generate(zipfile, year) -> None:
+        folder = Path(zipfile)
+        year = str(year)
+
+        if not folder.exists():
+            raise FileNotFoundError("Invalid path supplied.")
+
+        new_folder = RawLCF.data_dir / "tmp"
+        shutil.unpack_archive(folder, new_folder)
+        folder = new_folder
+
+        main_folder = next(folder.iterdir())
+        tab_folder = main_folder / "tab"
+        if tab_folder.exists():
+            criterion = re.compile(".*\.tab")
+            data_files = [
+                path
+                for path in tab_folder.iterdir()
+                if criterion.match(path.name)
+            ]
+            task = tqdm(data_files, desc="Saving raw data tables")
+            with pd.HDFStore(RawLCF.file(year)) as file:
+                for filepath in task:
+                    task.set_description(
+                        f"Saving raw data tables ({filepath.name})"
+                    )
+                    table_name = filepath.name.replace(".tab", "")
+                    df = pd.read_csv(
+                        filepath, delimiter="\t", low_memory=False
+                    ).apply(pd.to_numeric, errors="coerce")
+                    file[table_name] = df
+        else:
+            raise FileNotFoundError("Could not find the TAB files.")
+
+        tmp_folder = RawLCF.data_dir / "tmp"
+        if tmp_folder.exists():
+            safe_rmdir(tmp_folder)

--- a/openfisca_uk_data/generate.py
+++ b/openfisca_uk_data/generate.py
@@ -1,4 +1,16 @@
-from openfisca_uk_data import RawFRS, RawWAS, FRS, FRS_WAS_Imputation
+from openfisca_uk_data import (
+    RawFRS,
+    RawWAS,
+    FRS,
+    FRS_WAS_Imputation,
+    FRSEnhanced,
+)
+from openfisca_uk_data.datasets.lcf.raw_lcf import RawLCF
+
+print("Downloading WAS (2016)")
+RawWAS.download(2016)
+print("Downloading WAS (2019)")
+RawLCF.download(2019)
 
 for year in (2018, 2019):
     print(f"Downloading raw FRS ({year})")
@@ -12,3 +24,8 @@ print(f"Generating WAS-adjusted FRS (2019)")
 FRS_WAS_Imputation.generate(2019)
 print(f"Uploading WAS-adjusted FRS (2019)")
 FRS_WAS_Imputation.upload(2019)
+
+print(f"Generating enhanced FRS (2019)")
+FRSEnhanced.generate(2019)
+print(f"Uploading enhanced FRS (2019)")
+FRSEnhanced.upload(2019)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK-Data",
-    version="0.4.0",
+    version="0.5.0",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK-Data",
-    version="0.3.1",
+    version="0.4.0",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),


### PR DESCRIPTION
This adds the enhanced FRS dataset, containing:

* Carbon imputation from the LCF
* Land value imputation from the WAS

I've kept the FRS_WAS_Imp dataset for backwards compatibility to avoid breaking anything.

Also fixes a bug in the Council Tax imputation causing ~10% of households with no reported CT liability to remain with their negative (-1) value.