### PR TITLE
Add SSMG and split out education income

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.5] - 2022-01-12
+## [0.6.0] - 2022-01-12
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
-# 0.5.4
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.5] - 2022-01-12
+
+### Added
+
+* Sure Start Maternity Grant (reported).
+
+### Changed
+
+* Education payments split up into EMA (adult and child), Access Fund and grants.
+
+## [0.5.4]
+
+### Changed
 
 * Simplified synthetic dataset generation logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2022-01-12
+## [0.6.0] - 2022-01-13
 
 ### Added
 

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -528,7 +528,8 @@ def fill_with_mean(
         np.array: Filled values.
     """
     needs_fill = (table[code] == 1) & (table[amount] < 0)
-    fill_mean = table[amount][needs_fill].mean()
+    has_value = (table[code] == 1) & (table[amount] >= 0)
+    fill_mean = table[amount][has_value].mean()
     filled_values = np.where(needs_fill, fill_mean, table[code])
     return np.maximum(filled_values, 0)
 

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -531,7 +531,7 @@ def fill_with_mean(
     has_value = (table[code] == 1) & (table[amount] >= 0)
     fill_mean = table[amount][has_value].mean()
     filled_values = np.where(needs_fill, fill_mean, table[amount])
-    return np.maximum(filled_values, 0)
+    return np.maximum(filled_values, 0) * multiplier
 
 
 def add_benefit_income(

--- a/openfisca_uk_data/datasets/frs/frs.py
+++ b/openfisca_uk_data/datasets/frs/frs.py
@@ -530,7 +530,7 @@ def fill_with_mean(
     needs_fill = (table[code] == 1) & (table[amount] < 0)
     has_value = (table[code] == 1) & (table[amount] >= 0)
     fill_mean = table[amount][has_value].mean()
-    filled_values = np.where(needs_fill, fill_mean, table[code])
+    filled_values = np.where(needs_fill, fill_mean, table[amount])
     return np.maximum(filled_values, 0)
 
 

--- a/openfisca_uk_data/datasets/frs/synth_frs.py
+++ b/openfisca_uk_data/datasets/frs/synth_frs.py
@@ -7,7 +7,7 @@ import h5py
 import requests
 from tqdm import tqdm
 
-DEFAULT_SYNTH_FOLDER = "https://github.com/PolicyEngine/openfisca-uk-data/releases/download/synth-frs/"
+DEFAULT_SYNTH_FILE = "https://github.com/PolicyEngine/openfisca-uk-data/releases/download/synth-frs-2019/synth_frs_2019.h5"
 
 
 @dataset
@@ -55,9 +55,7 @@ class SynthFRS:
                         "S"
                     )
 
-    def save(data_file: str = None, year: int = 2018):
-        if data_file is None:
-            data_file = DEFAULT_SYNTH_FOLDER + f"synth_frs_{year}.h5"
+    def save(data_file: str = DEFAULT_SYNTH_FILE, year: int = 2019):
         if "https://" in data_file:
             response = requests.get(data_file, stream=True)
             total_size_in_bytes = int(

--- a/openfisca_uk_data/datasets/frs/ukmod/ukmod_output.py
+++ b/openfisca_uk_data/datasets/frs/ukmod/ukmod_output.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 import pandas as pd
-import numpy as np
-from microdf import MicroDataFrame
 from openfisca_uk_data.utils import dataset
 
 NON_MONTHLY_VARIABLES = (

--- a/openfisca_uk_data/tests/frs/test_synth_frs.py
+++ b/openfisca_uk_data/tests/frs/test_synth_frs.py
@@ -2,4 +2,4 @@ def test_synth_downloads():
     from openfisca_uk_data import SynthFRS
 
     SynthFRS.save()
-    assert SynthFRS.file(2018).exists()
+    assert SynthFRS.file(2019).exists()

--- a/openfisca_uk_data/tests/frs/variable_ukmod_map.yml
+++ b/openfisca_uk_data/tests/frs/variable_ukmod_map.yml
@@ -38,7 +38,6 @@ universal_credit_reported: bsauc
 PIP_M_reported: bdimbwa
 PIP_DL_reported: bdiscwa
 student_loans: bedsl
-student_payments: bedes
 council_tax_benefit_reported: bmu
 council_tax:
   ukmod: tmu02

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK-Data",
-    version="0.5.5",
+    version="0.6.0",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK-Data",
-    version="0.5.4",
+    version="0.5.5",
     description=(
         "A Python package to manage OpenFisca-UK-compatible microdata"
     ),


### PR DESCRIPTION
This adds Sure Start Maternity Grant (a small benefit, £28m in 2021), and splits out the education payment variables by type, to be summed in OpenFisca-UK.