### PR TITLE
Add install dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all:
+all: install
 	pip install wheel
 	python setup.py sdist bdist_wheel
 reset:


### PR DESCRIPTION
#68 failed to publish, because for some reason the make action didn't require a pip install. Adding now.